### PR TITLE
Avoid Race condition in Bundler

### DIFF
--- a/lib/tara/archive.rb
+++ b/lib/tara/archive.rb
@@ -39,6 +39,8 @@ module Tara
     #   the directory where the archive will be created.
     # @option config [Boolean] :bundle_ignore_config (false)
     #   if Bundler config should be ignored when installing dependencies
+    # @option config [Integer] :bundle_jobs (4)
+    #   the number of parallel workers to be used when installing gems
     # @option config [String] :download_dir (File.join(@config[:build_dir], 'downloads'))
     #   the directory where Traveling Ruby artifacts will be downloaded.
     # @option config [String] :archive_name (@config[:app_name] + '.tgz') name of the archive

--- a/lib/tara/installer.rb
+++ b/lib/tara/installer.rb
@@ -9,6 +9,7 @@ module Tara
       @without_groups = options[:without_groups]
       @app_dir = Pathname.new(options[:app_dir])
       @bundle_env = bundle_env(options[:bundle_ignore_config])
+      @bundle_jobs = options[:bundle_jobs] || 4
       @shell = options[:shell] || Shell
       @build_command = options[:build_command]
     end
@@ -35,7 +36,7 @@ module Tara
 
     def bundler_command
       @bundler_command ||= begin
-        command = 'bundle install --jobs 4 --frozen --path . --gemfile lib/vendor/Gemfile'
+        command = "bundle install --jobs #{@bundle_jobs} --frozen --path . --gemfile lib/vendor/Gemfile"
         command << %( --without #{@without_groups.join(' ')}) if @without_groups.any?
         command
       end


### PR DESCRIPTION
There is a race condition somewhere in Bundler or Rubygems that causes builds to fail when it tries to build two native extensions at the same time. This makes the number of parallel workers configurable to work around the problem.